### PR TITLE
Fix don't share CancellationTokens

### DIFF
--- a/ModbusTcp.Tests/UnitTest1.cs
+++ b/ModbusTcp.Tests/UnitTest1.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-
 namespace ModbusTcp.Tests
 {
     public class UnitTest1
@@ -19,7 +18,7 @@ namespace ModbusTcp.Tests
 
             Int32 port = 50222;
             string v4Loopback = ("127.0.0.1");
-            
+
             TcpListener server = new TcpListener(IPAddress.Parse(v4Loopback), port);
             server.Start();
 


### PR DESCRIPTION
In my previous PR I wrongly assumed i could share a CancellationToken and pass it around, turns out that has dramatic negative side effects (Tasks end unexpectedly).

Fixed by wrapping a CancellationToken inside a `using` block for each method. This fixes the problem that i accidentally introduced.

Default socket timeout has been set to 60 seconds. If you believe this is too aggressive we can always go up with that value.
