### PR TITLE
Support unitIDs other than 1.

### DIFF
--- a/ModbusTcp.Tests/UnitTest1.cs
+++ b/ModbusTcp.Tests/UnitTest1.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-
 namespace ModbusTcp.Tests
 {
     public class UnitTest1
@@ -19,7 +18,7 @@ namespace ModbusTcp.Tests
 
             Int32 port = 50222;
             string v4Loopback = ("127.0.0.1");
-            
+
             TcpListener server = new TcpListener(IPAddress.Parse(v4Loopback), port);
             server.Start();
 

--- a/ModbusTcp/ModbusClient.cs
+++ b/ModbusTcp/ModbusClient.cs
@@ -52,12 +52,12 @@ namespace ModbusTcp
         /// <param name="offset">The register offset</param>
         /// <param name="count">Number of words to read</param>
         /// <returns>The words read</returns>
-        public async Task<short[]> ReadRegistersAsync(int offset, int count)
+        public async Task<short[]> ReadRegistersAsync(int offset, int count, byte unit = 0x01)
         {
             if (tcpClient == null)
                 throw new Exception("Object not intialized");
 
-            var request = new ModbusRequest03(offset, count);
+            var request = new ModbusRequest03(offset, count, unit);
             var buffer = request.ToNetworkBuffer();
             await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
 
@@ -71,12 +71,12 @@ namespace ModbusTcp
         /// <param name="offset">The register offset</param>
         /// <param name="count">Number of floats to read</param>
         /// <returns>The floats read</returns>
-        public async Task<float[]> ReadRegistersFloatsAsync(int offset, int count)
+        public async Task<float[]> ReadRegistersFloatsAsync(int offset, int count, byte unit = 0x01)
         {
             if (tcpClient == null)
                 throw new Exception("Object not intialized");
 
-            var request = new ModbusRequest03(offset, count * 2 /* Float is 2 word */);
+            var request = new ModbusRequest03(offset, count * 2 /* Float is 2 word */, unit);
 
             var buffer = request.ToNetworkBuffer();
             await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
@@ -91,12 +91,12 @@ namespace ModbusTcp
         /// <param name="offset">The first register offset</param>
         /// <param name="values">The values to write</param>
         /// <returns>Awaitable task</returns>
-        public async Task WriteRegistersAsync(int offset, float[] values)
+        public async Task WriteRegistersAsync(int offset, float[] values, byte unit = 0x01)
         {
             if (tcpClient == null)
                 throw new Exception("Object not intialized");
 
-            var request = new ModbusRequest16(offset, values);
+            var request = new ModbusRequest16(offset, values, unit);
             var buffer = request.ToNetworkBuffer();
             await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
 
@@ -109,12 +109,12 @@ namespace ModbusTcp
         /// <param name="offset">The first register offset</param>
         /// <param name="values">The values to write</param>
         /// <returns>Awaitable task</returns>
-        public async Task WriteRegistersAsync(int offset, short[] values)
+        public async Task WriteRegistersAsync(int offset, short[] values, byte unit = 0x01)
         {
             if (tcpClient == null)
                 throw new Exception("Object not intialized");
 
-            var request = new ModbusRequest16();
+            var request = new ModbusRequest16(unit);
             request.WordCount = (short)(values.Length * 2);
             request.RegisterValues = values.ToNetworkBytes();
 

--- a/ModbusTcp/ModbusClient.cs
+++ b/ModbusTcp/ModbusClient.cs
@@ -13,23 +13,19 @@ namespace ModbusTcp
 {
     public class ModbusClient
     {
-        private CancellationToken cancellationToken;
-        private const int defaultSocketTimeout = 1800 * 1000; // 30 minutes
+        private int socketTimeout;
         private readonly int port;
         private TcpClient tcpClient;
         private NetworkStream transportStream;
         private readonly string ipAddress;
 
-        public ModbusClient(string ipAddress, int port, int socketTimeoutInMs = defaultSocketTimeout)
+        // Let's wait for 60 seconds for the socket if socketTimeout
+        // isn't passed by caller
+        public ModbusClient(string ipAddress, int port, int socketTimeout = 60000)
         {
             this.ipAddress = ipAddress;
             this.port = port;
-
-            // We'll pass this CancellationToken around to time-bound our network calls
-            var cancellationTokenSource = new CancellationTokenSource(socketTimeoutInMs);
-            cancellationTokenSource.Token.Register(() => transportStream.Close());
-            cancellationToken = cancellationTokenSource.Token;
-            cancellationToken.ThrowIfCancellationRequested();
+            this.socketTimeout = socketTimeout;
         }
 
         public void Init()
@@ -59,8 +55,14 @@ namespace ModbusTcp
 
             var request = new ModbusRequest03(offset, count, unit);
             var buffer = request.ToNetworkBuffer();
-            await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
 
+            using (var cancellationTokenSource = new CancellationTokenSource(socketTimeout))
+            {
+                using (cancellationTokenSource.Token.Register(() => transportStream.Close()))
+                {
+                    await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationTokenSource.Token);
+                }
+            }
             var response = await ReadResponseAsync<ModbusReply03>();
             return ReadAsShort(response.Data);
         }
@@ -79,7 +81,14 @@ namespace ModbusTcp
             var request = new ModbusRequest03(offset, count * 2 /* Float is 2 word */, unit);
 
             var buffer = request.ToNetworkBuffer();
-            await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+
+            using (var cancellationTokenSource = new CancellationTokenSource(socketTimeout))
+            {
+                using (cancellationTokenSource.Token.Register(() => transportStream.Close()))
+                {
+                    await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationTokenSource.Token);
+                }
+            }
 
             var response = await ReadResponseAsync<ModbusReply03>();
             return ReadAsFloat(response.Data);
@@ -98,8 +107,14 @@ namespace ModbusTcp
 
             var request = new ModbusRequest16(offset, values, unit);
             var buffer = request.ToNetworkBuffer();
-            await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
 
+            using (var cancellationTokenSource = new CancellationTokenSource(socketTimeout))
+            {
+                using (cancellationTokenSource.Token.Register(() => transportStream.Close()))
+                {
+                    await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationTokenSource.Token);
+                }
+            }
             var response = await ReadResponseAsync<ModbusReply16>();
         }
 
@@ -119,7 +134,14 @@ namespace ModbusTcp
             request.RegisterValues = values.ToNetworkBytes();
 
             var buffer = request.ToNetworkBuffer();
-            await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken);
+
+            using (var cancellationTokenSource = new CancellationTokenSource(socketTimeout))
+            {
+                using (cancellationTokenSource.Token.Register(() => transportStream.Close()))
+                {
+                    await transportStream.WriteAsync(buffer, 0, buffer.Length, cancellationTokenSource.Token);
+                }
+            }
 
             var response = await ReadResponseAsync<ModbusReply16>();
         }
@@ -189,18 +211,19 @@ namespace ModbusTcp
 
             while (remainder > 0)
             {
-                var readBytes = await transportStream.ReadAsync(buffer, idx, remainder, cancellationToken);
+                int readBytes = 0;
+                using (var cancellationTokenSource = new CancellationTokenSource(socketTimeout))
+                {
+                    using (cancellationTokenSource.Token.Register(() => transportStream.Close()))
+                    {
+                        readBytes = await transportStream.ReadAsync(buffer, idx, remainder, cancellationTokenSource.Token);
+                    }
+                }
                 remainder -= readBytes;
                 idx += readBytes;
 
                 if (readBytes == 0)
-                {
-                    if (cancellationToken.IsCancellationRequested)
-                        throw new TimeoutException("SocketTimeout reached, aborting network call. " +
-                            "You can adjust the timeout through the socketTimeoutInMs parameter of ModbusClient.");
-                    else
-                        throw new SocketException((int)SocketError.ConnectionReset);
-                }
+                    throw new SocketException((int)SocketError.ConnectionReset);
             }
 
             return buffer;

--- a/ModbusTcp/Protocol/Request/ModbusRequest03.cs
+++ b/ModbusTcp/Protocol/Request/ModbusRequest03.cs
@@ -7,14 +7,14 @@ namespace ModbusTcp.Protocol.Request
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     class ModbusRequest03 : ModbusBase
     {
-        public ModbusRequest03()
+        public ModbusRequest03(byte Unit = 0x01)
         {
             FunctionCode = 0x03;
-            UnitIdentifier = 0x01;
+            UnitIdentifier = Unit;
         }
 
-        public ModbusRequest03(int offset, int numberOfWords)
-            : this()
+        public ModbusRequest03(int offset, int numberOfWords, byte Unit = 0x01)
+            : this(Unit)
         {
             ReferenceNumber = (short)offset;
             WordCount = (short)numberOfWords;

--- a/ModbusTcp/Protocol/Request/ModbusRequest16.cs
+++ b/ModbusTcp/Protocol/Request/ModbusRequest16.cs
@@ -9,14 +9,14 @@ namespace ModbusTcp.Protocol.Request
     {
         public const int FixedLength = 7;
 
-        public ModbusRequest16()
+        public ModbusRequest16(byte Unit = 0x01)
         {
             FunctionCode = 0x10;
-            UnitIdentifier = 0x01;
+            UnitIdentifier = Unit;
         }
 
-        public ModbusRequest16(int offset, float[] values)
-            : this()
+        public ModbusRequest16(int offset, float[] values, byte Unit = 0x01)
+            : this(Unit)
         {
 
             ReferenceNumber = (short)offset;


### PR DESCRIPTION
I have setup where ModbusTcp gateway is used to make available several ModbusRTU devices available for computer network. Only one such device was available over initial code. These modifications make other devices available too.
I tried to keep call interface compatible by using default parameters.